### PR TITLE
Use font stack for code blocks

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -124,7 +124,7 @@ h6 {
 .theme-code-block,
 .prism-code,
 .token {
-    font-family: "Spline Sans Mono" !important;
+    font-family: "Spline Sans Mono", monospace !important;
 }
 
 .anchor-shadow:hover {


### PR DESCRIPTION
This ensures that it will use a monospace font for users that have custom fonts disabled.