### PR TITLE
fix minor typo in docs

### DIFF
--- a/docs/protocols/core.md
+++ b/docs/protocols/core.md
@@ -2169,7 +2169,7 @@ The "relative root" is the base domain of the server, which is used to retrieve 
 The uniqueness constraint of the identifier is important. If a collision occurs when trying to
 move the resource to another server, the resource cannot be migrated in a way that preserves the
 references to it. One way to ensure the uniqueness of the identifier is to use a hash function on the
-resource itself. Combining this has with a cryptographically strong nonce, then hashing the result of
+resource itself. Combining this hash with a cryptographically strong nonce, then hashing the result of
 concatenating the nonce and the hash of the resource should yield a unique identifier.
 
 The URI for resource addressing with relative roots is formatted as follows:


### PR DESCRIPTION
just adds a missing 'h' in the core docs. really interesting protocol btw